### PR TITLE
add personal bests onto classification table

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-b5f7729d'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.i13qjoc1rh"
+    "revision": "0.g0it7sifd1"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/components/ClassificationDetails.vue
+++ b/src/components/ClassificationDetails.vue
@@ -30,9 +30,11 @@ const classificationCalculator = computed(() => createClassificationCalculator(
 const totals = computed(() => calculateSubtotals(props.scores, props.gameType));
 const averageScoresPerEnd = computed(() => calculateAverageScorePerEnd(props.scores, props.endSize, props.gameType));
 const arrowsRemaining = computed(() => gameTypeConfig[props.gameType].maxArrows-props.scores.length)
-const maxPossibleScore = computed(() => totals.value.totalScore + (arrowsRemaining.value*gameTypeConfig[props.gameType].scores[0]))
-
-
+let maxPossibleArrowScore = gameTypeConfig[props.gameType].scores[0];
+if (maxPossibleArrowScore == 'X') {
+  maxPossibleArrowScore = 10;
+}
+const maxPossibleScore = computed(() => totals.value.totalScore + (arrowsRemaining.value*maxPossibleArrowScore));
 
 const availableClassifications = computed(() => {
   return classificationCalculator.value?.(
@@ -43,7 +45,9 @@ const availableClassifications = computed(() => {
 </script>
 
 <template>
-  <div v-if="availableClassifications">
+  <details claas="dropdown">
+    <summary>View Classification Calculation</summary>
+    <div v-if="availableClassifications">
     <table>
       <thead>
       <tr>
@@ -76,6 +80,7 @@ const availableClassifications = computed(() => {
       </tbody>
     </table>
   </div>
+  </details>
 </template>
 
 
@@ -89,6 +94,6 @@ const availableClassifications = computed(() => {
 }
 
 .failed {
-  text-decoration: line-through
+  text-decoration: line-through;
 }
 </style>

--- a/src/components/ClassificationDetails.vue
+++ b/src/components/ClassificationDetails.vue
@@ -5,6 +5,8 @@ import { createClassificationCalculator } from "@/domain/classification";
 import { calculateSubtotals } from "@/domain/subtotals";
 import { calculateAverageScorePerEnd } from "@/domain/rounds";
 import {gameTypeConfig} from "@/domain/game_types";
+import {convertToValue} from "@/domain/scores";
+import { useHistoryStore } from "@/stores/history";
 
 const props = defineProps({
   scores: {
@@ -19,22 +21,20 @@ const props = defineProps({
 });
 
 const userStore = useUserStore();
-
+const historyStore = useHistoryStore();
+const personalBest = computed(()=> historyStore.personalBest(props.gameType))
 const classificationCalculator = computed(() => createClassificationCalculator(
   props.gameType,
   userStore.user.gender,
   userStore.user.ageGroup,
-  userStore.user.bowType
+  userStore.user.bowType,
+  personalBest.value
 ));
 
 const totals = computed(() => calculateSubtotals(props.scores, props.gameType));
 const averageScoresPerEnd = computed(() => calculateAverageScorePerEnd(props.scores, props.endSize, props.gameType));
 const arrowsRemaining = computed(() => gameTypeConfig[props.gameType].maxArrows-props.scores.length)
-let maxPossibleArrowScore = gameTypeConfig[props.gameType].scores[0];
-if (maxPossibleArrowScore == 'X') {
-  maxPossibleArrowScore = 10;
-}
-const maxPossibleScore = computed(() => totals.value.totalScore + (arrowsRemaining.value*maxPossibleArrowScore));
+const maxPossibleScore = computed(() => totals.value.totalScore + (arrowsRemaining.value*convertToValue(gameTypeConfig[props.gameType].scores[0])));
 
 const availableClassifications = computed(() => {
   return classificationCalculator.value?.(

--- a/src/domain/classification.js
+++ b/src/domain/classification.js
@@ -68,7 +68,9 @@ export function calculateRoundScores(sex, bowtype, age, roundName, personalBest)
   const roundScores = rawClassifications
     .filter(c => classificationFilter(c))
     .sort(sortByScore);
-  roundScores.push({id: 10, gender: sex, bowType: bowtype, age: age, round: roundName, score: personalBest ?? 0});
+  if (personalBest) {
+    roundScores.push({id: 10, gender: sex, bowType: bowtype, age: age, round: roundName, score: personalBest ?? 0});
+  } 
   return roundScores;
 }
 

--- a/src/domain/classification.js
+++ b/src/domain/classification.js
@@ -68,7 +68,7 @@ export function calculateRoundScores(sex, bowtype, age, roundName, personalBest)
   const roundScores = rawClassifications
     .filter(c => classificationFilter(c))
     .sort(sortByScore);
-  roundScores.push({id: 10, gender: sex, bowType: bowtype, age: age, round: roundName, score: personalBest});
+  roundScores.push({id: 10, gender: sex, bowType: bowtype, age: age, round: roundName, score: personalBest ?? 0});
   return roundScores;
 }
 
@@ -80,7 +80,7 @@ export function calculateClassification(sex, age, bowtype) {
       const sorted = classifications.sort((a, b) => {
         return b.score - a.score;
       });
-      const wat = sorted.find(x => x.score <= score);
+      const wat = sorted.find(x => x.score <= score && x.name !=='PB');
       return wat?.name ?? "U/C";
     }
   };

--- a/src/domain/classification.test.js
+++ b/src/domain/classification.test.js
@@ -2,14 +2,13 @@ import { describe, expect, test } from "vitest";
 import { calculateClassification, createClassificationCalculator } from "@/domain/classification";
 
 describe("classification", () => {
-  const calculator = createClassificationCalculator("windsor", "male", "senior", "recurve", 0);
+  const calculator = createClassificationCalculator("windsor", "male", "senior", "recurve");
   test("can get classifications available for a round and given person who achieved A3", () => {
     expect(calculator(490, 30)).toEqual([
       { name: "A3", score: 490, achieved: true, shortBy: null, scorePerEnd: 28, perEndDiff: 2 },
       { name: "A2", score: 602, achieved: false, shortBy: 112, scorePerEnd: 34, perEndDiff: -4 },
       { name: "A1", score: 701, achieved: false, shortBy: 211, scorePerEnd: 39, perEndDiff: -9 },
       { name: "B3", score: 782, achieved: false, shortBy: 292, scorePerEnd: 44, perEndDiff: -14 },
-      { name: "PB", score: 0, achieved: true, shortBy: null, scorePerEnd: 0, perEndDiff: 30 }
     ]);
   });
 
@@ -19,7 +18,6 @@ describe("classification", () => {
       { name: "A2", score: 602, achieved: true, shortBy: null, scorePerEnd: 34, perEndDiff: -4 },
       { name: "A1", score: 701, achieved: true, shortBy: null, scorePerEnd: 39, perEndDiff: -9 },
       { name: "B3", score: 782, achieved: true, shortBy: null, scorePerEnd: 44, perEndDiff: -14 },
-      { name: "PB", score: 0, achieved: true, shortBy: null, scorePerEnd: 0, perEndDiff: 30 }
     ]);
   });
 
@@ -29,7 +27,6 @@ describe("classification", () => {
       { name: "A2", score: 602, achieved: true, shortBy: null, scorePerEnd: 34, perEndDiff: -4 },
       { name: "A1", score: 701, achieved: true, shortBy: null, scorePerEnd: 39, perEndDiff: -9 },
       { name: "B3", score: 782, achieved: false, shortBy: 10, scorePerEnd: 44, perEndDiff: -14 },
-      { name: "PB", score: 0, achieved: true, shortBy: null, scorePerEnd: 0, perEndDiff: 30 }
     ]);
   });
 });

--- a/src/domain/classification.test.js
+++ b/src/domain/classification.test.js
@@ -2,13 +2,14 @@ import { describe, expect, test } from "vitest";
 import { calculateClassification, createClassificationCalculator } from "@/domain/classification";
 
 describe("classification", () => {
-  const calculator = createClassificationCalculator("windsor", "male", "senior", "recurve");
+  const calculator = createClassificationCalculator("windsor", "male", "senior", "recurve", 0);
   test("can get classifications available for a round and given person who achieved A3", () => {
     expect(calculator(490, 30)).toEqual([
       { name: "A3", score: 490, achieved: true, shortBy: null, scorePerEnd: 28, perEndDiff: 2 },
       { name: "A2", score: 602, achieved: false, shortBy: 112, scorePerEnd: 34, perEndDiff: -4 },
       { name: "A1", score: 701, achieved: false, shortBy: 211, scorePerEnd: 39, perEndDiff: -9 },
-      { name: "B3", score: 782, achieved: false, shortBy: 292, scorePerEnd: 44, perEndDiff: -14 }
+      { name: "B3", score: 782, achieved: false, shortBy: 292, scorePerEnd: 44, perEndDiff: -14 },
+      { name: "PB", score: 0, achieved: true, shortBy: null, scorePerEnd: 0, perEndDiff: 30 }
     ]);
   });
 
@@ -17,7 +18,8 @@ describe("classification", () => {
       { name: "A3", score: 490, achieved: true, shortBy: null, scorePerEnd: 28, perEndDiff: 2 },
       { name: "A2", score: 602, achieved: true, shortBy: null, scorePerEnd: 34, perEndDiff: -4 },
       { name: "A1", score: 701, achieved: true, shortBy: null, scorePerEnd: 39, perEndDiff: -9 },
-      { name: "B3", score: 782, achieved: true, shortBy: null, scorePerEnd: 44, perEndDiff: -14 }
+      { name: "B3", score: 782, achieved: true, shortBy: null, scorePerEnd: 44, perEndDiff: -14 },
+      { name: "PB", score: 0, achieved: true, shortBy: null, scorePerEnd: 0, perEndDiff: 30 }
     ]);
   });
 
@@ -26,7 +28,8 @@ describe("classification", () => {
       { name: "A3", score: 490, achieved: true, shortBy: null, scorePerEnd: 28, perEndDiff: 2 },
       { name: "A2", score: 602, achieved: true, shortBy: null, scorePerEnd: 34, perEndDiff: -4 },
       { name: "A1", score: 701, achieved: true, shortBy: null, scorePerEnd: 39, perEndDiff: -9 },
-      { name: "B3", score: 782, achieved: false, shortBy: 10, scorePerEnd: 44, perEndDiff: -14 }
+      { name: "B3", score: 782, achieved: false, shortBy: 10, scorePerEnd: 44, perEndDiff: -14 },
+      { name: "PB", score: 0, achieved: true, shortBy: null, scorePerEnd: 0, perEndDiff: 30 }
     ]);
   });
 });


### PR DESCRIPTION
adding personal bests onto classification table, 

- Had to change the way the max score was calculated as metric rounds were showing NaN due to logic trying to multiply number of arrows with 'X' so just comparing the max possible arrow score and if it's an X changing it to a 10.
- Wrapped classification table in a details/summary as per suggestion from Ant 
- added calculatePersonalBest function to search through local storage for the highest score for that round and defaulting to 0 if no score has been submitted 
- changed how the roundScores are calculated due to using index made getting the correct label near impossible as rounds have differing numbers of classifications available, changed from a for loop using index to an array map using the id only downside is this needs to be subtracted by one as id's are not 0-indexed 

![image](https://github.com/user-attachments/assets/5fd1400b-6493-4905-9453-972f971d091f)
