### PR TITLE
update classification sorting to include PB

### DIFF
--- a/src/domain/classification.js
+++ b/src/domain/classification.js
@@ -67,10 +67,10 @@ export function calculateRoundScores(sex, bowtype, age, roundName, personalBest)
 
   const roundScores = rawClassifications
     .filter(c => classificationFilter(c))
-    .sort(sortByScore);
   if (personalBest) {
     roundScores.push({id: 10, gender: sex, bowType: bowtype, age: age, round: roundName, score: personalBest ?? 0});
   } 
+  roundScores.sort(sortByScore);
   return roundScores;
 }
 


### PR DESCRIPTION
as per @quii comment on the last PR it would be nice if your PB is sorted in the classification table so it appears in the correct location ie inbetween the rows for A1 and B3 this is simple I just needed to change the point at which the scores are sorted to be after I've added in the PB into the roundScores array 