### PR TITLE
Fix Worcester Max Possible Score

### DIFF
--- a/src/domain/scoring/scores.js
+++ b/src/domain/scoring/scores.js
@@ -19,5 +19,5 @@ export function convertToValues(scores, gameType = "national") {
 }
 
 export const calculateMaxPossibleScore = (totalScoreSoFar, arrowsRemaining, gameType) => {
-  return totalScoreSoFar + (arrowsRemaining * convertToValue(gameTypeConfig[gameType].scores[0]));
+  return totalScoreSoFar + (arrowsRemaining * convertToValue(gameTypeConfig[gameType].scores[0], gameType));
 }


### PR DESCRIPTION
as the gameType was not being passed into convertToValue an X was being seen as 10 as such for a worcester round it was displaying the max possible score as 600 when in reality it's 300, passing in the gameType makes the existing logic for worcester scoring work and show max score as 300.